### PR TITLE
fix: carousel working as intended

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
             </div>
             <div class="col-12 text-center mt-4 mt-lg-5">
               <p>
-                <span class="concert-text concert hover-target">Portfolio</span>
+                <span class="concert-text concert hover-target">portfolio</span>
               </p>
             </div>
           </div>
@@ -95,13 +95,13 @@
             class="row"
             id="gallery"
             data-toggle="modal"
-            data-target="#Modalp"
+            data-target="#exampleModal"
           >
             <div class="col-md-6 col-lg-4">
               <img
                 src="static/portfolio/1.jpg"
                 class="portfolio-photo"
-                data-target="#carouselp"
+                data-target="#carouselExample"
                 data-slide-to="0"
                 alt="First portfolio photo"
               />
@@ -110,7 +110,7 @@
               <img
                 src="static/portfolio/2.jpg"
                 class="portfolio-photo"
-                data-target="#carouselp"
+                data-target="#carouselExample"
                 data-slide-to="1"
                 alt="Second portfolio photo"
               />
@@ -119,7 +119,7 @@
               <img
                 src="static/portfolio/3.jpg"
                 class="portfolio-photo"
-                data-target="#carouselp"
+                data-target="#carouselExample"
                 data-slide-to="2"
                 alt="Third portfolio photo"
               />
@@ -128,7 +128,7 @@
               <img
                 src="static/portfolio/4.jpg"
                 class="portfolio-photo"
-                data-target="#carouselp"
+                data-target="#carouselExample"
                 data-slide-to="3"
                 alt="Fourth portfolio photo"
               />
@@ -137,7 +137,7 @@
               <img
                 src="static/portfolio/5.jpg"
                 class="portfolio-photo"
-                data-target="#carouselp"
+                data-target="#carouselExample"
                 data-slide-to="4"
                 alt="Fifth portfolio photo"
               />
@@ -146,7 +146,7 @@
               <img
                 src="static/portfolio/6.jpg"
                 class="portfolio-photo"
-                data-target="#carouselp"
+                data-target="#carouselExample"
                 data-slide-to="5"
                 alt="Sixth portfolio photo"
               />
@@ -155,7 +155,7 @@
               <img
                 src="static/portfolio/7.jpg"
                 class="portfolio-photo"
-                data-target="#carouselp"
+                data-target="#carouselExample"
                 data-slide-to="6"
                 alt="Seventh portfolio photo"
               />
@@ -164,7 +164,7 @@
               <img
                 src="static/portfolio/8.JPG"
                 class="portfolio-photo"
-                data-target="#carouselp"
+                data-target="#carouselExample"
                 data-slide-to="7"
                 alt="Eighth portfolio photo"
               />
@@ -173,7 +173,7 @@
               <img
                 src="static/portfolio/9.jpg"
                 class="portfolio-photo"
-                data-target="#carouselp"
+                data-target="#carouselExample"
                 data-slide-to="8"
                 alt="Ninth portfolio photo"
               />
@@ -182,7 +182,7 @@
               <img
                 src="static/portfolio/10.jpg"
                 class="portfolio-photo"
-                data-target="#carouselp"
+                data-target="#carouselExample"
                 data-slide-to="9"
                 alt="Tenth portfolio photo"
               />
@@ -191,7 +191,7 @@
               <img
                 src="static/portfolio/11.jpg"
                 class="portfolio-photo"
-                data-target="#carouselp"
+                data-target="#carouselExample"
                 data-slide-to="10"
                 alt="Eleventh portfolio photo"
               />
@@ -200,7 +200,7 @@
               <img
                 src="static/portfolio/12.jpg"
                 class="portfolio-photo"
-                data-target="#carouselp"
+                data-target="#carouselExample"
                 data-slide-to="11"
                 alt="Twelfth portfolio photo"
               />
@@ -209,7 +209,7 @@
               <img
                 src="static/portfolio/13.jpg"
                 class="portfolio-photo"
-                data-target="#carouselp"
+                data-target="#carouselExample"
                 data-slide-to="12"
                 alt="Thirteenth portfolio photo"
               />
@@ -218,7 +218,7 @@
               <img
                 src="static/portfolio/14.jpg"
                 class="portfolio-photo"
-                data-target="#carouselp"
+                data-target="#carouselExample"
                 data-slide-to="13"
                 alt="Fourteenth portfolio photo"
               />
@@ -227,7 +227,7 @@
               <img
                 src="static/portfolio/15.jpg"
                 class="portfolio-photo"
-                data-target="#carouselp"
+                data-target="#carouselExample"
                 data-slide-to="14"
                 alt="Fifteenth portfolio photo"
               />
@@ -236,7 +236,7 @@
               <img
                 src="static/portfolio/16.jpg"
                 class="portfolio-photo"
-                data-target="#carouselp"
+                data-target="#carouselExample"
                 data-slide-to="15"
                 alt="Sixteenth portfolio photo"
               />
@@ -245,7 +245,7 @@
               <img
                 src="static/portfolio/17.jpg"
                 class="portfolio-photo"
-                data-target="#carouselp"
+                data-target="#carouselExample"
                 data-slide-to="16"
                 alt="Seventeenth portfolio photo"
               />
@@ -254,7 +254,7 @@
               <img
                 src="static/portfolio/18.JPG"
                 class="portfolio-photo"
-                data-target="#carouselp"
+                data-target="#carouselExample"
                 data-slide-to="17"
                 alt="Eighteenth portfolio photo"
               />
@@ -267,7 +267,7 @@
     <!-- modal start -->
     <div
       class="modal"
-      id="Modalp"
+      id="exampleModal"
       tabindex="-1"
       role="dialog"
       aria-hidden="true"
@@ -287,34 +287,34 @@
           </div>
           <div class="modal-body">
             <div
-              id="carousel"
+              id="carouselExample"
               class="carousel slide"
               data-ride="carousel"
             >
               <ol class="carousel-indicators">
                 <li
-                  data-target="#carouselp"
+                  data-target="#carouselExample"
                   data-slide-to="0"
                   class="active"
                 ></li>
-                <li data-target="#carouselp" data-slide-to="1"></li>
-                <li data-target="#carouselp" data-slide-to="2"></li>
-                <li data-target="#carouselp" data-slide-to="3"></li>
-                <li data-target="#carouselp" data-slide-to="4"></li>
-                <li data-target="#carouselp" data-slide-to="5"></li>
-                <li data-target="#carouselp" data-slide-to="6"></li>
-                <li data-target="#carouselp" data-slide-to="7"></li>
-                <li data-target="#carouselp" data-slide-to="8"></li>
-                <li data-target="#carouselp" data-slide-to="9"></li>
-                <li data-target="#carouselp" data-slide-to="10"></li>
-                <li data-target="#carouselp" data-slide-to="11"></li>
-                <li data-target="#carouselp" data-slide-to="12"></li>
-                <li data-target="#carouselp" data-slide-to="13"></li>
-                <li data-target="#carouselp" data-slide-to="14"></li>
-                <li data-target="#carouselp" data-slide-to="15"></li>
-                <li data-target="#carouselp" data-slide-to="16"></li>
-                <li data-target="#carouselp" data-slide-to="17"></li>
-                <li data-target="#carouselp" data-slide-to="18"></li>
+                <li data-target="#carouselExample" data-slide-to="1"></li>
+                <li data-target="#carouselExample" data-slide-to="2"></li>
+                <li data-target="#carouselExample" data-slide-to="3"></li>
+                <li data-target="#carouselExample" data-slide-to="4"></li>
+                <li data-target="#carouselExample" data-slide-to="5"></li>
+                <li data-target="#carouselExample" data-slide-to="6"></li>
+                <li data-target="#carouselExample" data-slide-to="7"></li>
+                <li data-target="#carouselExample" data-slide-to="8"></li>
+                <li data-target="#carouselExample" data-slide-to="9"></li>
+                <li data-target="#carouselExample" data-slide-to="10"></li>
+                <li data-target="#carouselExample" data-slide-to="11"></li>
+                <li data-target="#carouselExample" data-slide-to="12"></li>
+                <li data-target="#carouselExample" data-slide-to="13"></li>
+                <li data-target="#carouselExample" data-slide-to="14"></li>
+                <li data-target="#carouselExample" data-slide-to="15"></li>
+                <li data-target="#carouselExample" data-slide-to="16"></li>
+                <li data-target="#carouselExample" data-slide-to="17"></li>
+                <li data-target="#carouselExample" data-slide-to="18"></li>
               </ol>
               <div class="carousel-inner">
                 <div class="carousel-item active">
@@ -446,7 +446,7 @@
               </div>
               <a
                 class="carousel-control-prev"
-                href="#carouselp"
+                href="#carouselExample"
                 role="button"
                 data-slide="prev"
               >
@@ -458,7 +458,7 @@
               </a>
               <a
                 class="carousel-control-next"
-                href="#carouselp"
+                href="#carouselExample"
                 role="button"
                 data-slide="next"
               >


### PR DESCRIPTION
Revert a former change that broke the photo carousel as well as changing the portfolio button on the main page to lower letters.